### PR TITLE
feat(template): templating for pr-body

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "github-change-remote-file": "^1.0.0",
+    "github-url-from-git": "^1.4.0",
+    "lodash.template": "^3.6.2",
     "semver": "^5.0.1"
   },
   "devDependencies": {

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,6 +1,6 @@
 Dear Hoodie maintainer,
 
-A hoodie component just released a new major version.
+[<%= name %>](<%= repository.url %>) just released a new major version -- [<%= version %>](<%= release %>).
 I'm just a bot and unfortunately I can't yet know if that breaks Hoodie as well.
 
 Generally if a breaking change appears in a component there are two options:


### PR DESCRIPTION
This is the start of #2.

I wanted to do a short initial go, as I wanted to see if I was doing the right thing.

When I tried to do a demo this was my output:

``````
{ [Function]
  source: 'function(obj) {\nobj || (obj = {});\nvar __t, __p = \'\';\nwith (obj) {\n__p += \'Dear Hoodie maintainer,\\n\\n\' +\n((__t = ( component )) == null ? \'\' : __t) +\n\' just released a new major version.\\nI\\\'m just a bot and unfortunately I can\\\'t yet know if that breaks Hoodie as well.\\n\\nGenerally if a breaking change appears in a component there are two options:\\n\\n1. A new version of an accompanying component makes up for the breaking change, so that if they\\\'re used together the public API doesn\\\'t break.\\n2. This is an actual breaking change for Hoodie as well.\\n\\nPlease try and figure that out with your amazing human brain.\\n\\nIn case of the former please wait for the accompanying component to release its new version and manually update both versions in one commit. You can close this PR.\\n\\nIn case of the latter please document the breaking change by adding another empty commit that declares the breaking change and includes migration instructions.\\n\\nThis could look something like this:\\n\\n```\\ngit commit --allow-empty\\n```\\n\\nThe editor opens.\\n\\n> docs(changelog): declare breaking change\\n>\\n> BREAKING CHANGE: Feature xyz broke in version x.y.z of hoodie-whatever.\\n>\\n> Please use hoodie.foo() instead of hoodie.bar() from now on.\\n\\n\\n\\nThank you,\\n\\n– HoodieBot :heart:\\n\';\n\n}\nreturn __p\n}' }
``````

Which as someone new to lodash.template, I couldn't tell if it was doing the right thing or not.

How is this, @boennemann?

:frog: 
