### PR TITLE
feat: Add release type to pr-body

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,11 @@ function pushOrPR (oldVersion, newVersion) {
   oldVersion = oldVersion.replace(/^[\^~]/, '')
 
   if (!semver.valid(oldVersion)) {
+
+    // In the pr this will say:
+    // [Name] just released a new 'version' -- [version]
+    pkg.type = 'version'
+
     return {
       message: 'chore(package): ' + messageFragment,
       pr: {
@@ -56,6 +61,11 @@ function pushOrPR (oldVersion, newVersion) {
   var diff = semver.diff(oldVersion, newVersion)
 
   if (diff === 'major') {
+
+    // In the pr this will say:
+    // [Name] just released a new 'major version' -- [version]
+    pkg.type = 'major version'
+
     // we don't really know if it's a feature or fix
     // so we just use the `chore` type so this can be determined by humans
     // also we're only sending a PR rather than pushing to master
@@ -72,6 +82,11 @@ function pushOrPR (oldVersion, newVersion) {
   }
 
   if (diff === 'minor') {
+
+    // In the pr this will say:
+    // [Name] just released a new 'minor version' -- [version]
+    pkg.type = 'minor version'
+
     return {
       message: 'feat(package): ' + messageFragment,
       push: true
@@ -79,12 +94,21 @@ function pushOrPR (oldVersion, newVersion) {
   }
 
   if (diff === 'patch') {
+
+    // In the pr this will say:
+    // [Name] just released a new 'patch' -- [version]
+    pkg.type = 'patch'
+
     return {
       message: 'fix(package): ' + messageFragment,
       push: true
     }
 
   }
+
+  // In the pr this will say:
+  // [Name] just released a new 'version' -- [version]
+  pkg.type = 'version'
 
   return {
     message: 'chore(package): ' + messageFragment,

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,6 +1,6 @@
 Dear Hoodie maintainer,
 
-[<%= name %>](<%= repository.url %>) just released a new major version -- [<%= version %>](<%= release %>).
+[<%= name %>](<%= repository.url %>) just released a new <%= type %> -- [<%= version %>](<%= release %>).
 I'm just a bot and unfortunately I can't yet know if that breaks Hoodie as well.
 
 Generally if a breaking change appears in a component there are two options:


### PR DESCRIPTION
This fixes #5.

I am not sure if I've defined the right type of version for a couple of them. Particularly for https://github.com/hoodiehq/bundle-bump-bot/blob/fa2c8ca0278d53d99dc240c2bab86ab0344fe527/index.js#L47 as I have no idea what that semver control block does? If you tell me I can add a comment to that block in the repo :)
Also unsure if the right version type was defined for the last return statement.

Any help would be appreciated!

:panda_face:
